### PR TITLE
F2125 remove path param

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -78,15 +78,6 @@ resource "aws_api_gateway_stage" "default" {
   stage_name    = "default"
 }
 
-resource "aws_apigatewayv2_api_mapping" "this-deprecated" {
-  count = var.path != "" ? 1 : 0
-
-  api_id          = aws_api_gateway_rest_api.this.id
-  domain_name     = local.domain_name
-  api_mapping_key = var.path
-  stage           = aws_api_gateway_stage.default.stage_name
-}
-
 resource "aws_apigatewayv2_api_mapping" "this" {
   for_each = var.paths
 

--- a/variables.tf
+++ b/variables.tf
@@ -12,15 +12,6 @@ locals {
   invoke_arn = var.app_metadata["invoke_arn"]
 }
 
-variable "path" {
-  type        = string
-  default     = ""
-  description = <<EOF
-The path to route to this application. Any requests to the API Gateway beginning with this path will be routed to this application.
-This variable is being deprecated in favor of the "paths" variable. Please use the "paths" variable instead.
-EOF
-}
-
 variable "paths" {
   type        = set(string)
   default     = []


### PR DESCRIPTION
This PR removes the deprecated `path` param. Instead, users should use the `paths` param, where they can specify multiple paths as a list.